### PR TITLE
Update default values for  --assign/--no-assign

### DIFF
--- a/jiratools/__init__.py
+++ b/jiratools/__init__.py
@@ -174,17 +174,19 @@ def _test_story_args():
     _load_config()
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument("jira_id")
-    parser.set_defaults(assign=bool(CONFIG["DEFAULT_ASSIGNEE"]))
+    assign_default = bool(CONFIG["DEFAULT_ASSIGNEE"])
     assignment = parser.add_mutually_exclusive_group()
     assignment.add_argument(
         "--assign",
         dest="assign",
+        default=assign_default,
         action="store_true",
         help="Assign story to user, current user if none provided.",
     )
     assignment.add_argument(
         "--no-assign",
         dest="assign",
+        default=not assign_default,
         action="store_false",
         help="Leave Test JIRA unassigned",
     )

--- a/jiratools/__version__.py
+++ b/jiratools/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 2, 2)
+VERSION = (1, 2, 3)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Using set_defaults on the destination caused the
help message to show the same default value for
both --assign and --no-assign which is... confusing.

You can test this by changing the DEFAULT_ASSIGNEE in your ~/jira.config and using `-h` to see the defaults shown.
