### PR TITLE
Fix.py35 fix

### DIFF
--- a/jiratools/__version__.py
+++ b/jiratools/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 3, 0)
+VERSION = (1, 3, 1)
 
 __version__ = ".".join(map(str, VERSION))

--- a/jiratools/formatting.py
+++ b/jiratools/formatting.py
@@ -3,7 +3,7 @@ import os
 
 
 def _build_source():
-    return os.environ.get("BUILD_URL", f"Manual run by {getpass.getuser()}")
+    return os.environ.get("BUILD_URL", "Manual run by {}".format(getpass.getuser()))
 
 
 def format_autoupdate_jira_msg(message_body, header_body=None):


### PR DESCRIPTION
Missed an f-string to `.format()` conversion for py35 compatibility.