### PR TITLE
Make config more general use

### DIFF
--- a/jiratools/jira.config.example
+++ b/jiratools/jira.config.example
@@ -1,10 +1,10 @@
 [jira]
-JIRA_URL=https://jira.rax.io
+JIRA_URL=https://jira.atlassian.com
 USERNAME=YOUR_USERNAME
 PASSWORD=YOUR_PASSWORD
 # Leave assignee blank for a default Unassigned JIRA
 DEFAULT_ASSIGNEE=%(USERNAME)s
-TEST_PROJECT=YOUR_QE_PROJECT
+TEST_PROJECT=YOUR_JIRA_PROJECT
 DEFAULT_ISSUE_TYPE=Story
 DEFAULT_DESCRIPTION=Do necessary QE testing around the linked Dev JIRA
 # Summary can expect two values passed in to .format() - 1) dev_jira_id, 2) dev_jira_summary


### PR DESCRIPTION
Two things I thought of (and you can throw this back to me if you want me to change):

-should we also make default description and default summary more general use? 

